### PR TITLE
Fix list.sort() argument passing

### DIFF
--- a/sqlalchemy_mutable/mutable_list.py
+++ b/sqlalchemy_mutable/mutable_list.py
@@ -147,9 +147,9 @@ class MutableList(Mutable, list):
         self._changed()
         return super().pop(index)
 
-    def sort(self, cmp=None, key=None, reverse=False):
+    def sort(self, /, *, key=None, reverse=False):
         self._changed()
-        return super().sort(cmp=cmp, key=key, reverse=reverse)
+        return super().sort(key=key, reverse=reverse)
     
     # 3. Unshell models when returning list iterator
     def unshell(self):


### PR DESCRIPTION
Thanks for the library, this is working great!
We just hit this minor issue with the sort argument.

`cmp` doesn't exist anymore (that was removed with python 3), and so fails with
```
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/datatypes/mothur.py", line 78, in set_meta
    dataset.metadata.labels.sort()
  File "/home/runner/work/galaxy/galaxy/galaxy root/.venv/lib/python3.7/site-packages/sqlalchemy_mutable/mutable_list.py", line 152, in sort
    return super().sort(cmp=cmp, key=key, reverse=reverse)
TypeError: sort() takes at most 2 keyword arguments (3 given)
```